### PR TITLE
Fixes for the job widget styles

### DIFF
--- a/wp-content/themes/currentorg/style.css
+++ b/wp-content/themes/currentorg/style.css
@@ -719,7 +719,7 @@ article .entry-content p {
 .widget.rev a {
   color: #0082a3;
 }
-.widget.rev > .widgettitle {
+#sidebar .widget.rev h3.widgettitle {
   margin-top: 24px;
 }
 

--- a/wp-content/themes/currentorg/style.css
+++ b/wp-content/themes/currentorg/style.css
@@ -711,13 +711,16 @@ article .entry-content p {
 /* 5.5.17 Homepage Job Board Widget Styles */
 
 #sidebar .widget.rev {
-  padding: 24px 0 0 0;
+  padding: 0;
   background-color: #fff;
   border: 1px solid #ddd;
   margin-left: 24px;
 }
 .widget.rev a {
   color: #0082a3;
+}
+.widget.rev > .widgettitle {
+  margin-top: 24px;
 }
 
 .jt_job_list  a {

--- a/wp-content/themes/currentorg/style.css
+++ b/wp-content/themes/currentorg/style.css
@@ -710,10 +710,14 @@ article .entry-content p {
 
 /* 5.5.17 Homepage Job Board Widget Styles */
 
-.jt_job_list {
-  padding: 0px;
+#sidebar .widget.rev {
+  padding: 24px 0 0 0;
   background-color: #fff;
   border: 1px solid #ddd;
+  margin-left: 24px;
+}
+.widget.rev a {
+  color: #0082a3;
 }
 
 .jt_job_list  a {

--- a/wp-content/themes/currentorg/style.css
+++ b/wp-content/themes/currentorg/style.css
@@ -710,15 +710,15 @@ article .entry-content p {
 
 /* 5.5.17 Homepage Job Board Widget Styles */
 
-#sidebar .widget.widget-3 {
+.jt_job_list {
   padding: 0px;
-  padding-top: 40px;
   background-color: #fff;
   border: 1px solid #ddd;
 }
 
-.widget.widget-3 a {
+.jt_job_list  a {
   color: #0082a3;
+  font-weight: bold;
 }
 
 .jt_row1,


### PR DESCRIPTION
## Changes


This revises the changes made in https://github.com/INN/umbrella-currentorg/pull/4 for https://secure.helpscout.net/conversation/399464192/1094/?folderId=1219602:

- scopes border and padding styles to the "reverse" widget style instead of `.widget-3`