### PR TITLE
Modify the Wallit and Chartbeat codes to attempt to set up chartbeat user-type integrations

### DIFF
--- a/wp-content/themes/currentorg/functions.php
+++ b/wp-content/themes/currentorg/functions.php
@@ -273,7 +273,6 @@ function current_wallit_js() {
 					if ( maybe_anon ) {
 						try {
 							_cbq.push(['_acct', 'anon']);
-							console.log( 'logging anonymous chartbeater' );
 						} catch (e) {
 							console.log('Error when trying to pass the Wallit anonymous status to Chartbeat.');
 							console.log(e);

--- a/wp-content/themes/currentorg/functions.php
+++ b/wp-content/themes/currentorg/functions.php
@@ -247,6 +247,8 @@ function current_wallit_js() {
 					} catch (e) {
 						console.log('Error when trying to pass the Wallit logged-in status to Chartbeat.');
 						console.log(e);
+					} finally {
+						console.log('attempted to pass the lgdin status to chartbeat');
 					}
 
 					if (data.AccessReason == 'Purchase' || data.AccessReason == 'Dubscription' ) {
@@ -255,6 +257,8 @@ function current_wallit_js() {
 						} catch (e) {
 							console.log('Error when trying to pass the Wallit paid status to Chartbeat.');
 							console.log(e);
+						} finally {
+							console.log('attempted to pass the paid status to chartbeat');
 						}
 					}
 				}

--- a/wp-content/themes/currentorg/functions.php
+++ b/wp-content/themes/currentorg/functions.php
@@ -241,19 +241,19 @@ function current_wallit_js() {
 			'0bf27215-847a-4f97-93f5-6633b76d27ff',
 			{
 				accessGranted: function(data) {
+					var maybe_anon = true;
 					_cbq = window._cbq = (window._cbq || []);
 					if (
 						data.AccessReason == 'Purchase'
 						|| data.AccessReason == 'Subscription'
 						|| data.AccessReason == 'PropertyUser'
 					) {
+						maybe_anon = false;
 						try {
 							_cbq.push(['_acct', 'lgdin']);
 						} catch (e) {
 							console.log('Error when trying to pass the Wallit logged-in status to Chartbeat.');
 							console.log(e);
-						} finally {
-							console.log('attempted to pass the lgdin status to chartbeat');
 						}
 					}
 
@@ -261,13 +261,22 @@ function current_wallit_js() {
 						data.AccessReason == 'Purchase'
 						|| data.AccessReason == 'Subscription'
 					) {
+						maybe_anon = false;
 						try {
 							_cbq.push(['_acct', 'paid']);
 						} catch (e) {
 							console.log('Error when trying to pass the Wallit paid status to Chartbeat.');
 							console.log(e);
-						} finally {
-							console.log('attempted to pass the paid status to chartbeat');
+						}
+					}
+
+					if ( ! maybe_anon ) {
+						try {
+							_cbq.push(['_acct', 'anon']);
+							console.log( 'logging anonymous chartbeater' );
+						} catch (e) {
+							console.log('Error when trying to pass the Wallit anonymous status to Chartbeat.');
+							console.log(e);
 						}
 					}
 				}
@@ -291,11 +300,14 @@ function current_chartbeat() {
 		_cbq = window._cbq = (window._cbq || []);
 		<?php
 
+		/**
+		 * not sure if they actually want to count wordpress users as logged-in
 		if ( is_user_logged_in() ) {
 			echo "_cbq.push(['_acct', 'lgdin']);";
 		} else {
 			echo "_cbq.push(['_acct', 'anon']);";
 		}
+		*/
 		?>
 		/** CONFIGURATION END **/
 

--- a/wp-content/themes/currentorg/functions.php
+++ b/wp-content/themes/currentorg/functions.php
@@ -306,7 +306,8 @@ function current_chartbeat() {
 
 		/** CONFIGURATION START **/
 		_sf_async_config.uid = 57004;
-		_sf_async_config.domain = 'current.org'
+		/** _sf_async_config.domain = 'current.org' */
+		_sf_async_config.domain = 'currentorg.staging.wpengine.com'
 		_sf_async_config.useCanonical = true;
 		_cbq = window._cbq = (window._cbq || []);
 		<?php

--- a/wp-content/themes/currentorg/functions.php
+++ b/wp-content/themes/currentorg/functions.php
@@ -244,9 +244,9 @@ function current_wallit_js() {
 					var maybe_anon = true;
 					_cbq = window._cbq = (window._cbq || []);
 					if (
-						data.AccessReason == 'Purchase'
-						|| data.AccessReason == 'Subscription'
-						|| data.AccessReason == 'PropertyUser'
+						data.AccessReason === 'Purchase'
+						|| data.AccessReason === 'Subscription'
+						|| data.AccessReason === 'PropertyUser'
 					) {
 						maybe_anon = false;
 						try {
@@ -258,8 +258,8 @@ function current_wallit_js() {
 					}
 
 					if (
-						data.AccessReason == 'Purchase'
-						|| data.AccessReason == 'Subscription'
+						data.AccessReason === 'Purchase'
+						|| data.AccessReason === 'Subscription'
 					) {
 						maybe_anon = false;
 						try {

--- a/wp-content/themes/currentorg/functions.php
+++ b/wp-content/themes/currentorg/functions.php
@@ -226,7 +226,7 @@ add_action('largo_after_home_list_post', 'current_insert_home_list_widget_area',
 /**
  * wallit paywall, with some Chartbeat logging integration
  *
- * When the wallit user is granted access:
+ * When a wallit user (has a wallit account) is granted access:
  * - attempt to push the 'lgdin' status to chartbeat
  * - if the reason for granting the access is because of money, try to push the 'paid' status to chartbeat
  *
@@ -242,16 +242,25 @@ function current_wallit_js() {
 			{
 				accessGranted: function(data) {
 					_cbq = window._cbq = (window._cbq || []);
-					try {
-						_cbq.push(['_acct', 'lgdin']);
-					} catch (e) {
-						console.log('Error when trying to pass the Wallit logged-in status to Chartbeat.');
-						console.log(e);
-					} finally {
-						console.log('attempted to pass the lgdin status to chartbeat');
+					if (
+						data.AccessReason == 'Purchase'
+						|| data.AccessReason == 'Subscription'
+						|| data.AccessReason == 'PropertyUser'
+					) {
+						try {
+							_cbq.push(['_acct', 'lgdin']);
+						} catch (e) {
+							console.log('Error when trying to pass the Wallit logged-in status to Chartbeat.');
+							console.log(e);
+						} finally {
+							console.log('attempted to pass the lgdin status to chartbeat');
+						}
 					}
 
-					if (data.AccessReason == 'Purchase' || data.AccessReason == 'Dubscription' ) {
+					if (
+						data.AccessReason == 'Purchase'
+						|| data.AccessReason == 'Subscription'
+					) {
 						try {
 							_cbq.push(['_acct', 'paid']);
 						} catch (e) {
@@ -272,7 +281,7 @@ add_action( 'wp_head', 'current_wallit_js' );
 
 function current_chartbeat() {
 	?>
-	<script type='text/javascript'>
+	<script type='text/javascript' id="current_chartbeat">
 		var _sf_async_config = _sf_async_config || {};
 
 		/** CONFIGURATION START **/

--- a/wp-content/themes/currentorg/functions.php
+++ b/wp-content/themes/currentorg/functions.php
@@ -270,7 +270,7 @@ function current_wallit_js() {
 						}
 					}
 
-					if ( ! maybe_anon ) {
+					if ( maybe_anon ) {
 						try {
 							_cbq.push(['_acct', 'anon']);
 							console.log( 'logging anonymous chartbeater' );

--- a/wp-content/themes/currentorg/functions.php
+++ b/wp-content/themes/currentorg/functions.php
@@ -226,6 +226,8 @@ add_action('largo_after_home_list_post', 'current_insert_home_list_widget_area',
 /**
  * wallit paywall, with some Chartbeat logging integration
  *
+ * If user is logged in, this script does not output.
+ *
  * When a wallit user (has a wallit account) is granted access:
  * - attempt to push the 'lgdin' status to chartbeat
  * - if the reason for granting the access is because of money, try to push the 'paid' status to chartbeat
@@ -234,6 +236,8 @@ add_action('largo_after_home_list_post', 'current_insert_home_list_widget_area',
  * @link https://wallit.github.io/api/js#resourceaccessdataquota-object
  */
 function current_wallit_js() {
+	if ( is_user_logged_in() )
+		return;
 	?>
 		<script src="https://cdn.wallit.io/paywall.min.js"></script>
 		<script type="text/javascript">
@@ -287,7 +291,15 @@ function current_wallit_js() {
 add_action( 'wp_head', 'current_wallit_js' );
 
 
+/**
+ * Chartbeat tracking script.
+ *
+ * If user is logged in, this script does not output.
+ *
+ */
 function current_chartbeat() {
+	if ( is_user_logged_in() )
+		return;
 	?>
 	<script type='text/javascript' id="current_chartbeat">
 		var _sf_async_config = _sf_async_config || {};
@@ -299,14 +311,6 @@ function current_chartbeat() {
 		_cbq = window._cbq = (window._cbq || []);
 		<?php
 
-		/**
-		 * not sure if they actually want to count wordpress users as logged-in
-		if ( is_user_logged_in() ) {
-			echo "_cbq.push(['_acct', 'lgdin']);";
-		} else {
-			echo "_cbq.push(['_acct', 'anon']);";
-		}
-		*/
 		?>
 		/** CONFIGURATION END **/
 


### PR DESCRIPTION
Sends the following status if the following conditions are met:

- anon: a visitor is not logged in as a WordPress user
- lgdin: a visitor is logged in as a WordPress user, OR a visitor passes the Wallit paywall
- paid: a visitor passes the Wallit paywall using a method that Wallit registers as requiring a payment

The Wallit statuses require Wallit to load, which means that visitors with adblockers that block Wallit's scripts will be logged as 'anon' unless they're (like me) a logged-in WordPress user.

This is a continuation of the work in #6.

The portion of this that depends upon Wallit is contained within the `accessGranted` method, described here: https://wallit.github.io/api/js#resourceaccessdata-object#i-need-to-replace-my-content-on-access-granted-with-the-full-content

The Wallit type-of-pass information is described here: https://wallit.github.io/api/js#resourceaccessdataquota-object

## Questions for review

- does this look like it works?
- do we have a wallit login that can be used for testing?