### PR TITLE
Add hierarchical terms for requested custom tag taxonomies.

### DIFF
--- a/wp-content/themes/currentorg/functions.php
+++ b/wp-content/themes/currentorg/functions.php
@@ -4,16 +4,31 @@ define('FEATURED_MEDIA', true);
 
 
 /**
- * Register a custom homepage layout
+ * Include theme files and register a homepage layout
  *
+ * Based off of how Largo loads files: https://github.com/INN/Largo/blob/master/functions.php#L358
+ *
+ * 1. hook function Largo() on after_setup_theme
+ * 2. function Largo() runs Largo::get_instance()
+ * 3. Largo::get_instance() runs Largo::require_files()
+ *
+ * This function is intended to be easily copied between child themes, and for that reason is not prefixed with this child theme's normal prefix.
+ *
+ * @link https://github.com/INN/Largo/blob/master/functions.php#L145
  * @see "homepages/layouts/current.php"
- */
-function current_register_custom_homepage_layout() {
+nc */
+function largo_child_require_files() {
 	// load the layout
-	include_once __DIR__ . '/homepages/layouts/current.php';
-	register_homepage_layout('CurrentHomepage');
+	$includes = array(
+		'/homepages/layouts/current.php',
+		'/inc/custom-taxonomies.php'
+	);
+	foreach ( $includes as $include ) {
+		require_once( get_stylesheet_directory() . $include );
+	}
+	register_homepage_layout( 'CurrentHomepage' );
 }
-add_action('init', 'current_register_custom_homepage_layout', 0);
+add_action( 'init', 'largo_child_require_files', 0 );
 
 
 /**

--- a/wp-content/themes/currentorg/inc/custom-taxonomies.php
+++ b/wp-content/themes/currentorg/inc/custom-taxonomies.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Functions relating to Current.org's custom taxonomies
+ *
+ * This adds custom hierarchical hidden taxonomies for:
+ * - City
+ * - State
+ * - Sources quoted in the story
+ * - Stations mentioned in story
+ * - Source, where "Source" is something like: Press Release, Hearken, Tip, Pitch, Other publication, Event, Reporter Idea, Editor idea, Social media
+ *
+ * Hierarchical was chosen because it avoids duplication of terms and variation on capitalization: problems that would require use of the Term Debt Consolidator.
+ *
+ * @link https://secure.helpscout.net/conversation/452083230/1388/?folderId=1219602
+ */
+
+/**
+ * Register these custom taxonomies
+ *
+ * @since WordPress 4.8.2
+ */
+function current_register_taxonomies() {
+	register_taxonomy(
+		'current-city',
+		'post',
+		array(
+			'public' => true,
+			'publicly_queryable' => false,
+			'show_ui' => true,
+			'show_in_menu' => true,
+			'show_in_nav_menus' => false,
+			'show_in_rest' => true,
+			'show_in_quick_edit' => true,
+			'show_admin_column' => false,
+			'description' => 'Cities, towns, municipalities and other regions involved in posts.',
+			'hierarchical' => true,
+			'labels' => array(
+				'name' => __( 'City', 'current' ),
+				'singular_name' => __( 'City', 'current' ),
+				'menu_name' => __( 'Cities', 'current' ),
+				'all_items' => __( 'All Cities', 'current' ),
+				'edit_item' => __( 'Edit City', 'current' ),
+				'view_item' => __( 'View City', 'current' ),
+				'update_item' => __( 'Update City', 'current' ),
+				'parent_item' => __( 'Parent City', 'current' ),
+				'parent_item_colon' => __( 'Parent City:', 'current' ),
+				'search_items' => __( 'Search Cities', 'current' ),
+				'popular_items' => __( 'Popular Cities', 'current' ),
+				'not_found' => __( 'City not located.', 'current' ),
+				'add_new_item' => __( 'Add a new City', 'current' ),
+				'new_item_name' => __( 'New City Name', 'current' ),
+			)
+		)
+	);
+	
+	register_taxonomy(
+		'current-state',
+		'post',
+		array(
+			'public' => true,
+			'publicly_queryable' => false,
+			'show_ui' => true,
+			'show_in_menu' => true,
+			'show_in_nav_menus' => false,
+			'show_in_rest' => true,
+			'show_in_quick_edit' => true,
+			'show_admin_column' => false,
+			'description' => 'States and other territories mentioned in posts.',
+			'hierarchical' => true,
+			'labels' => array(
+				'name' => __( 'State', 'current' ),
+				'singular_name' => __( 'State', 'current' ),
+				'menu_name' => __( 'States', 'current' ),
+				'all_items' => __( 'All States', 'current' ),
+				'edit_item' => __( 'Edit State', 'current' ),
+				'view_item' => __( 'View State', 'current' ),
+				'update_item' => __( 'Update State', 'current' ),
+				'parent_item' => __( 'Parent State', 'current' ),
+				'parent_item_colon' => __( 'Parent State:', 'current' ),
+				'search_items' => __( 'Search States', 'current' ),
+				'popular_items' => __( 'Popular States', 'current' ),
+				'not_found' => __( 'States not located.', 'current' ),
+				'add_new_item' => __( 'Add a new state', 'current' ),
+				'new_item_name' => __( 'New State Name', 'current' ),
+			)
+		)
+	);
+	register_taxonomy(
+		'current-mentioned-sources',
+		'post',
+		array(
+			'public' => true,
+			'publicly_queryable' => false,
+			'show_ui' => true,
+			'show_in_menu' => true,
+			'show_in_nav_menus' => false,
+			'show_in_rest' => true,
+			'show_in_quick_edit' => true,
+			'show_admin_column' => false,
+			'description' => 'Quoted sources and documents mentioned in posts.',
+			'hierarchical' => true,
+			'labels' => array(
+				'name' => __( 'Mentioned Sources', 'current' ),
+				'singular_name' => __( 'Mentioned Source', 'current' ),
+				'menu_name' => __( 'Mentioned Sources', 'current' ),
+				'all_items' => __( 'All Mentioned Sources', 'current' ),
+				'edit_item' => __( 'Edit Mentioned Source', 'current' ),
+				'view_item' => __( 'View Mentioned Source', 'current' ),
+				'update_item' => __( 'Update Mentioned Source', 'current' ),
+				'parent_item' => __( 'Parent Mentioned Source', 'current' ),
+				'parent_item_colon' => __( 'Parent Mentioned Source:', 'current' ),
+				'search_items' => __( 'Search Mentioned Sources', 'current' ),
+				'popular_items' => __( 'Popular Mentioned Sources', 'current' ),
+				'not_found' => __( 'Mentioned Source not found.', 'current' ),
+				'add_new_item' => __( 'Add a new mentioned source', 'current' ),
+				'new_item_name' => __( 'New Source Name', 'current' ),
+			)
+		)
+	);
+	register_taxonomy(
+		'current-mentioned-stations',
+		'post',
+		array(
+			'public' => true,
+			'publicly_queryable' => false,
+			'show_ui' => true,
+			'show_in_menu' => true,
+			'show_in_nav_menus' => false,
+			'show_in_rest' => true,
+			'show_in_quick_edit' => true,
+			'show_admin_column' => false,
+			'description' => 'Member stations mentioned in posts.',
+			'hierarchical' => true,
+			'labels' => array(
+				'name' => __( 'Mentioned Station', 'current' ),
+				'singular_name' => __( 'Station', 'current' ),
+				'menu_name' => __( 'Stations', 'current' ),
+				'all_items' => __( 'All Stations', 'current' ),
+				'edit_item' => __( 'Edit Station', 'current' ),
+				'view_item' => __( 'View Station', 'current' ),
+				'update_item' => __( 'Update Station', 'current' ),
+				'parent_item' => __( 'Parent Station', 'current' ),
+				'parent_item_colon' => __( 'Parent Station:', 'current' ),
+				'search_items' => __( 'Search Stations', 'current' ),
+				'popular_items' => __( 'Popular Stations', 'current' ),
+				'not_found' => __( 'Station not located.', 'current' ),
+				'add_new_item' => __( 'Add a new Station', 'current' ),
+				'new_item_name' => __( 'New Station Name', 'current' ),
+			)
+		)
+	);
+	register_taxonomy(
+		'current-source',
+		'post',
+		array(
+			'public' => true,
+			'publicly_queryable' => false,
+			'show_ui' => true,
+			'show_in_menu' => true,
+			'show_in_nav_menus' => false,
+			'show_in_rest' => true,
+			'show_in_quick_edit' => true,
+			'show_admin_column' => false,
+			'description' => 'Where did we get the initial idea for this post?',
+			'hierarchical' => true,
+			'labels' => array(
+				'name' => __( 'Source of Story', 'current' ),
+				'singular_name' => __( 'Source', 'current' ),
+				'menu_name' => __( 'Sources', 'current' ),
+				'all_items' => __( 'All Sources', 'current' ),
+				'edit_item' => __( 'Edit Source', 'current' ),
+				'view_item' => __( 'View Source', 'current' ),
+				'update_item' => __( 'Update Source', 'current' ),
+				'parent_item' => __( 'Parent Source', 'current' ),
+				'parent_item_colon' => __( 'Parent Source:', 'current' ),
+				'search_items' => __( 'Search Sources', 'current' ),
+				'popular_items' => __( 'Popular Sources', 'current' ),
+				'not_found' => __( 'Source not found.', 'current' ),
+				'add_new_item' => __( 'Add a new Source', 'current' ),
+				'new_item_name' => __( 'New Source Type', 'current' ),
+			)
+		)
+	);
+}
+add_action( 'init', 'current_register_taxonomies', 10 );


### PR DESCRIPTION
Adds:
- City
- State
- Sources quoted in story
- Stations mentioned in story
- Source, where "Source" is something like: Press release, Hearken, Tip,
Pitch, Other publication, Event, Reporter idea, Editor idea, Social media

Hierarchical because that helps prevent duplication.

Also bumps Largo to 0.5.5.4


By request, see https://secure.helpscout.net/conversation/452083230/1388/