### PR TITLE
Fix homepage byline sizes

### DIFF
--- a/wp-content/themes/currentorg/style.css
+++ b/wp-content/themes/currentorg/style.css
@@ -357,7 +357,8 @@ header .newsletter-signup .submit {
 
 /* 2.2 Post styles */
 
-.entry-content * {
+.page .entry-content,
+.single .entry-content {
   font-size: 22px;
 }
 .entry-content p {
@@ -366,6 +367,12 @@ header .newsletter-signup .submit {
   font-weight: 400;
   font-style: normal;
   line-height: 1.5;
+  font-size: inherit;
+}
+.entry-content ul,
+.entry-content ol,
+.entry-content li {
+  font-size: inherit;
 }
 h1.entry-title {
   font-size: 52px;


### PR DESCRIPTION
## Changes

- limits the font-size: 22px; to .entry-content on posts and pages
- changes from a * to an inherit-based opt-in approach for elements, because * was bad.

## After

A continuation of https://secure.helpscout.net/conversation/681505022/2624/?folderId=1211656 and a fix for https://secure.helpscout.net/conversation/691654317/2739/?folderId=1219602, redoing https://github.com/INN/umbrella-currentorg/commit/d267a01e81e80dbaa9e5e6b22f8abd3effeeba9b