### PR TITLE
Workaround for undefined function array_key_last

### DIFF
--- a/wp-content/themes/currentorg/business-directory/single_content.tpl.php
+++ b/wp-content/themes/currentorg/business-directory/single_content.tpl.php
@@ -27,7 +27,9 @@
                         get_term_link( $category )
                     );
     
-                    if( $index != array_key_last( $listing_categories ) ){
+                    $number_of_categories = count( $listing_categories );
+    
+                    if( $index != ( $number_of_categories - 1 ) ){
                         echo '<span> | </span>';
                     }
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Swapped out using `array_key_last`.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
Current is on PHP 7.1 and `array_key_last` is  7.3 function, causing `undefined function array_key_last` errors.

## Testing/Questions

Features that this PR affects:

- Listing detail page

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this ok?

Steps to test this PR:

1. Navigate to single listing page and verify you can see it.

## Additional information

INN Member/Labs Client requesting: (if applicable)

- [ ] Contributor has read INN's [GitHub code of conduct](https://github.com/INN/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] Contributor would like to be mentioned in the release notes as: (fill in this blank)
- [ ] Contributor agrees to the license terms of this repository.
