### PR TITLE
Only fire verify_tags function on wpbdp_listing in the admin and...

### DIFF
--- a/wp-content/themes/currentorg/inc/business-directory-plugin.php
+++ b/wp-content/themes/currentorg/inc/business-directory-plugin.php
@@ -241,37 +241,48 @@ add_action( 'admin_head', 'wpbdp_tag_cloud_custom_css_js' );
  */
 function wpbdp_verify_tags_on_post_save( $post_id ){
 
-	// grab the current listing categories and tags
-	$wpbdp_listing_categories = get_the_terms( $post_id, 'wpbdp_category' );
-	$wpbdp_listing_tags = get_the_terms( $post_id, 'wpbdp_tag' );
+	$post = get_post( $post_id );
+	$post_type = $post->post_type;
+	
+	if( $post_type == 'wpbdp_listing' && is_admin() ){
 
-	// loop through each saved tag
-	foreach( $wpbdp_listing_tags as $wpbdp_listing_tag ){
+		// grab the current listing categories and tags
+		$wpbdp_listing_categories = get_the_terms( $post_id, 'wpbdp_category' );
+		$wpbdp_listing_tags = get_the_terms( $post_id, 'wpbdp_tag' );
 
-		$wpbdp_tag_meta = get_term_meta( $wpbdp_listing_tag->term_id );
-		
-		$wpbdp_tag_parent_category = $wpbdp_tag_meta['wpbdp_tag_parent_category'][0];
-		$wpbdp_tag_parent_category = str_replace( 'wpbdp_category--', '', $wpbdp_tag_parent_category );
+		if( $wpbdp_listing_tags ){
 
-		$wpbdp_tag_parent_category_selected = false;
+			// loop through each saved tag
+			foreach( $wpbdp_listing_tags as $wpbdp_listing_tag ){
 
-		// loop through each saved listing category and if a parent category is found
-		// with an id that matches the tag parent id, set $wpbdp_tag_parent_category_selected = true
-		foreach( $wpbdp_listing_categories as $key => $wpbdp_listing_category ){
+				$wpbdp_tag_meta = get_term_meta( $wpbdp_listing_tag->term_id );
+				
+				$wpbdp_tag_parent_category = $wpbdp_tag_meta['wpbdp_tag_parent_category'][0];
+				$wpbdp_tag_parent_category = str_replace( 'wpbdp_category--', '', $wpbdp_tag_parent_category );
 
-			if( $wpbdp_listing_category->term_id == $wpbdp_tag_parent_category ){
+				$wpbdp_tag_parent_category_selected = false;
 
-				$wpbdp_tag_parent_category_selected = true;
+				// loop through each saved listing category and if a parent category is found
+				// with an id that matches the tag parent id, set $wpbdp_tag_parent_category_selected = true
+				foreach( $wpbdp_listing_categories as $key => $wpbdp_listing_category ){
+
+					if( $wpbdp_listing_category->term_id == $wpbdp_tag_parent_category ){
+
+						$wpbdp_tag_parent_category_selected = true;
+
+					}
+
+				}
+
+				// if no parent category has been found with a matching id, 
+				// let's go ahead and remove the tag that shouldn't be there
+				if( !$wpbdp_tag_parent_category_selected ){
+
+					wp_remove_object_terms( $post_id, $wpbdp_listing_tag->term_id, 'wpbdp_tag' );
+
+				}
 
 			}
-
-		}
-
-		// if no parent category has been found with a matching id, 
-		// let's go ahead and remove the tag that shouldn't be there
-		if( !$wpbdp_tag_parent_category_selected ){
-
-			wp_remove_object_terms( $post_id, $wpbdp_listing_tag->term_id, 'wpbdp_tag' );
 
 		}
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Updated `wpbdp_verify_tags_on_post_save` function on `save_post` hook to only fire if the post type is `wpbdp_listing`, if `is_admin()`, and if `wpbdp_listing_tags` is not empty.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #23. On the frontend submit listing page, there was a warning `Invalid argument supplied for foreach()` for this:

https://github.com/INN/umbrella-currentorg/blob/c8e6dcc54c39277c44aa4620cbb0741746af08ca/wp-content/themes/currentorg/inc/business-directory-plugin.php#L249-L279

Apparently when you load the frontend submit listing page, it fires the `save_post` hook.

## Testing/Questions

Features that this PR affects:

- Category specific tags being verified on post save.

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Does the tag verification still work? 
- [ ] Does the tag verification fire anywhere it isn't expected to?

Steps to test this PR:

1. View `site/directory-of-services/?wpbdp_view=submit_listing` and make sure there's no `Invalid argument supplied for foreach()` warning.
