### PR TITLE
50 update landing page boxes to only show category description

### DIFF
--- a/wp-content/themes/currentorg/business-directory/main_page.tpl.php
+++ b/wp-content/themes/currentorg/business-directory/main_page.tpl.php
@@ -101,16 +101,6 @@
 								'<p class="category-description">%1$s</p>',
 								esc_html__( 'The companies featured here offer the following services to public media:', 'currentorg' )
 							);
-							echo '<ul>';
-							foreach ( $tags as $tag ) {
-								printf(
-									'<li class="%1$s"><a href="%2$s">%3$s</a></li>',
-									WPBDP_TAGS_TAX . '-' . $tag->term_id,
-									get_term_link( $tag ),
-									esc_html( $tag->name )
-								);
-							}
-							echo '</ul>';
 						} else {
 							printf(
 								'<p class="category-description">%1$s</p>',

--- a/wp-content/themes/currentorg/business-directory/main_page.tpl.php
+++ b/wp-content/themes/currentorg/business-directory/main_page.tpl.php
@@ -91,23 +91,10 @@
 							);
 						}
 
-						/**
-						 * Get the term's tags and output them
-						 *
-						 */
-						$tags = wpbdp_get_tags_by_category( $term );
-						if ( ! empty ( $tags ) ) {
-							printf(
-								'<p class="category-description">%1$s</p>',
-								esc_html__( 'The companies featured here offer the following services to public media:', 'currentorg' )
-							);
-						} else {
-							printf(
-								'<p class="category-description">%1$s</p>',
-								wp_kses_post( apply_filters( 'category_description', $term->description, $term ), true)
-							);
-						}
-						unset( $tags );
+						printf(
+							'<p class="category-description">%1$s</p>',
+							wp_kses_post( apply_filters( 'category_description', $term->description, $term ), true)
+						);
 
 						printf(
 							'<a class="listing-link" href="%1$s">%2$s</a>',


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes list of child tags from the parent category boxes on the BDP landing page.

Before:
![Screen Shot 2019-07-01 at 4 09 02 PM](https://user-images.githubusercontent.com/18353636/60463682-a4d4c100-9c1a-11e9-9c1c-a8c52ca02c91.png)

After:
![Screen Shot 2019-07-01 at 4 09 14 PM](https://user-images.githubusercontent.com/18353636/60463689-a900de80-9c1a-11e9-86bb-77eba0475f26.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #50.

## Testing/Questions

Features that this PR affects:

- Landing page category boxes.

Steps to test this PR:

1. View the BDP landing page `/directory-of-services/`. No config change needed.
