### PR TITLE
48 text on more views

### DIFF
--- a/wp-content/themes/currentorg/inc/business-directory-plugin.php
+++ b/wp-content/themes/currentorg/inc/business-directory-plugin.php
@@ -375,7 +375,7 @@ function wpbdp_filter_the_content(){
 	 *
 	 * For https://github.com/INN/umbrella-currentorg/issues/48 .
 	 */
-	if( wpbdp_check_if_specific_wpbdp_view( array( 'submit_listing' ) ) ){
+	if( wpbdp_check_if_specific_wpbdp_view( array( 'submit_listing', 'login' ) ) ){
 
 		$post->post_content = __( '<p>Public media is a $3.5 billion industry comprised of hundreds of radio and TV stations that serve nearly every community in the U.S. Public broadcasters seek trusted vendors for a wide range of services that will help their stations succeed. Current is where they connect with you.</p>', 'currentorg');
 		$post->post_content .= '[businessdirectory]';


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds the text requested in #48 to the login page as well.

Before:
![Screen Shot 2019-07-01 at 18 42 35 ](https://user-images.githubusercontent.com/1754187/60470854-094e4b00-9c30-11e9-8b85-7c0b3a200e13.png)


After:
![Screen Shot 2019-07-01 at 18 42 21 ](https://user-images.githubusercontent.com/1754187/60470859-0e12ff00-9c30-11e9-9c89-58b512abeea2.png)

## Why

Based on feedback in testing.
Part of #48.

## Testing/Questions

Features that this PR affects:

- the login page

Steps to test this PR:

1. Visit `/directory-of-services/?wpbdp_view=login` when logged out
