### PR TITLE
Add logo back to above sidebar

### DIFF
--- a/wp-content/themes/currentorg/business-directory/single_content.tpl.php
+++ b/wp-content/themes/currentorg/business-directory/single_content.tpl.php
@@ -92,9 +92,11 @@
 		if ( is_object( $images ) ) {
 			$img_ids = array();
 
-			if ( isset( $images->main ) && is_object( $images->main ) && is_numeric( $images->main->id ) ) {
-				$img_ids[] = $images->main->id;
-			}
+            // this is commented out for now because the main (logo) image should be above the sidebar
+            // but maybe one day we'll need to add this back
+			// if ( isset( $images->main ) && is_object( $images->main ) && is_numeric( $images->main->id ) ) {
+			// 	$img_ids[] = $images->main->id;
+			// }
 			
 			if ( isset( $images->extra ) && is_array( $images->extra ) ) {
 				foreach ( $images->extra as $image ) {

--- a/wp-content/themes/currentorg/business-directory/single_content.tpl.php
+++ b/wp-content/themes/currentorg/business-directory/single_content.tpl.php
@@ -92,11 +92,9 @@
 		if ( is_object( $images ) ) {
 			$img_ids = array();
 
-            // this is commented out for now because the main (logo) image should be above the sidebar
-            // but maybe one day we'll need to add this back
-			// if ( isset( $images->main ) && is_object( $images->main ) && is_numeric( $images->main->id ) ) {
-			// 	$img_ids[] = $images->main->id;
-			// }
+			if ( isset( $images->main ) && is_object( $images->main ) && is_numeric( $images->main->id ) ) {
+				$img_ids[] = $images->main->id;
+			}
 			
 			if ( isset( $images->extra ) && is_array( $images->extra ) ) {
 				foreach ( $images->extra as $image ) {

--- a/wp-content/themes/currentorg/partials/sidebar-wpbdp-listing-sidebar.php
+++ b/wp-content/themes/currentorg/partials/sidebar-wpbdp-listing-sidebar.php
@@ -1,19 +1,21 @@
 <div class="listing-sidebar">
 
     <?php
+
         $listing_id = $wp_query->query_vars['_wpbdp_listing'];
-        $wpbdp_listings_api = wpbdp_listings_api();
-        $listing_thumbnail_id = wpbdp_listings_api()->get_thumbnail_id( $listing_id );
-        $listing_thumbnail_url = wp_get_attachment_url( $listing_thumbnail_id );
-        
-        if ( $listing_thumbnail_id && $listing_thumbnail_url ){
+        $listing_logo = wpbdp_get_form_field( 11 );
+
+        if ( is_object( $listing_logo ) && $listing_logo->value( $listing_id ) ){
+
             printf(
                 '<div class="listing-main-image">
                     <img src="%1$s">
                 </div>',
-                $listing_thumbnail_url
+                $listing_logo->value( $listing_id )
             );
+
         }
+
     ?>
     <hr/>
     <div class="listing-services">

--- a/wp-content/themes/currentorg/partials/sidebar-wpbdp-listing-sidebar.php
+++ b/wp-content/themes/currentorg/partials/sidebar-wpbdp-listing-sidebar.php
@@ -1,23 +1,31 @@
 <div class="listing-sidebar">
 
-    <?php
+	<?php
 
-        $listing_id = $wp_query->query_vars['_wpbdp_listing'];
-        $listing_logo = wpbdp_get_form_field( 11 );
+		$listing_id = $wp_query->query_vars['_wpbdp_listing'];
+		$listing_logo = wpbdp_get_form_field( 11 );
 
-        if ( is_object( $listing_logo ) && $listing_logo->value( $listing_id ) ){
+		if ( is_object( $listing_logo ) && $listing_logo->value( $listing_id ) ) {
 
-            printf(
-                '<div class="listing-main-image">
-                    <img src="%1$s">
-                </div>',
-                $listing_logo->value( $listing_id )
-            );
+			// $listing_logo->value( $listing_id ) returns an array (
+			//     0 => image ID
+			//     1 => image description
+			// )
+			$img_data = $listing_logo->value( $listing_id );
 
-        }
+			if ( isset( $img_data[0] ) && is_numeric( $img_data[0] ) ) {
+				printf(
+					'<div class="listing-main-image">
+						%1$s
+					</div>',
+					wp_get_attachment_image( $img_data[0], 'full', false )
+				);
+			}
 
-    ?>
-    <hr/>
+
+		}
+
+	?>
     <div class="listing-services">
         <h3>Services</h3>
         <hr/>

--- a/wp-content/themes/currentorg/partials/sidebar-wpbdp-listing-sidebar.php
+++ b/wp-content/themes/currentorg/partials/sidebar-wpbdp-listing-sidebar.php
@@ -1,5 +1,21 @@
 <div class="listing-sidebar">
 
+    <?php
+        $listing_id = $wp_query->query_vars['_wpbdp_listing'];
+        $wpbdp_listings_api = wpbdp_listings_api();
+        $listing_thumbnail_id = wpbdp_listings_api()->get_thumbnail_id( $listing_id );
+        $listing_thumbnail_url = wp_get_attachment_url( $listing_thumbnail_id );
+        
+        if ( $listing_thumbnail_id && $listing_thumbnail_url ){
+            printf(
+                '<div class="listing-main-image">
+                    <img src="%1$s">
+                </div>',
+                $listing_thumbnail_url
+            );
+        }
+    ?>
+    <hr/>
     <div class="listing-services">
         <h3>Services</h3>
         <hr/>

--- a/wp-content/themes/currentorg/partials/sidebar-wpbdp-listing-sidebar.php
+++ b/wp-content/themes/currentorg/partials/sidebar-wpbdp-listing-sidebar.php
@@ -17,14 +17,12 @@
 				printf(
 					'<div class="listing-main-image">
 						%1$s
-					</div>',
+					</div>
+					<hr/>',
 					wp_get_attachment_image( $img_data[0], 'full', false )
 				);
 			}
-
-
 		}
-
 	?>
     <div class="listing-services">
         <h3>Services</h3>


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Added the listing specified logo back to above the sidebar on the right, instead of being mixed into the `extra` images below the content.

Before:
![Screen Shot 2019-07-09 at 9 55 01 AM](https://user-images.githubusercontent.com/18353636/60894074-03f49000-a230-11e9-874d-6c9886fd11e6.png)

After:
![Screen Shot 2019-07-09 at 9 53 11 AM](https://user-images.githubusercontent.com/18353636/60894075-03f49000-a230-11e9-9828-c46f8dcfddea.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #73 / #86

## Testing/Questions

Features that this PR affects:

- Single listing page

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] The logo should **not** also appear under the content, right?

Steps to test this PR:

1. Edit the `Logo` field and uncheck `Display this value in the listing view.`.
2. View a single listing with a logo
3. Make sure the logo appears above the sidebar rather than below the content.