### PR TITLE
Update global nav bar and don't miss menu font sizes

### DIFF
--- a/wp-content/themes/currentorg/style.css
+++ b/wp-content/themes/currentorg/style.css
@@ -751,3 +751,11 @@ article .entry-content p {
   font-size: 14px;
   color: #000;
 }
+
+.global-nav ul{
+  font-size: 14px;
+}
+
+#topics-bar #menu-dont-miss li{
+  font-size: 16px;
+}


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Updated global nav bar font size to 14px
- Updated don't miss menu font size to 16px

Before:
![Screen Shot 2019-07-22 at 11 35 36 AM](https://user-images.githubusercontent.com/18353636/61646849-f3093d00-ac79-11e9-8399-f3b3c9581187.png)

After:
![Screen Shot 2019-07-22 at 11 34 38 AM](https://user-images.githubusercontent.com/18353636/61646850-f3093d00-ac79-11e9-9f58-e6bcb5961431.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #88 

## Testing/Questions

Features that this PR affects:

- Global nav bar
- Don't Miss menu

Steps to test this PR:

1. Verify the global nav bar font size looks ok
2. Verify the Don't Miss menu font size looks ok

