### PR TITLE
133: Project metadata metaboxes

### DIFF
--- a/wp-content/plugins/current-ltw-projects/post-types/projects.php
+++ b/wp-content/plugins/current-ltw-projects/post-types/projects.php
@@ -192,6 +192,9 @@ add_action( 'add_meta_boxes', 'projects_add_meta_box' );
  * The meta box for the project meta fields
  */
 function projects_meta_box( $post ) {
+	?>
+		<h1>hola</h1>
+	<?php
 	// project-contact-name - text
 	// project-contact-email - email
 	// project-organization - text

--- a/wp-content/plugins/current-ltw-projects/post-types/projects.php
+++ b/wp-content/plugins/current-ltw-projects/post-types/projects.php
@@ -121,6 +121,84 @@ function projects_post_meta_items() {
 	return array(
 		array(
 			'post',
+			'project-submitter-name',
+			array(
+				'object_subtype' => 'projects',
+				'type' => 'string',
+				'description' => esc_html__('The name of the person who submitted this project. Kept private.', 'currentorg' ),
+				'single' => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				// 'auth_callback' => .... I don't know the answer to this question.
+				'show_in_rest' => true,
+
+				// now for our private arguments
+				'_projects_input_type' => 'text', // HTML input type
+			)
+		),
+		array(
+			'post',
+			'project-submitter-email',
+			array(
+				'object_subtype' => 'projects',
+				'type' => 'string',
+				'description' => esc_html__('The email address of the person who submitted this project. Kept private.', 'currentorg' ),
+				'single' => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				// 'auth_callback' => .... I don't know the answer to this question.
+				'show_in_rest' => true,
+
+				// now for our private arguments
+				'_projects_input_type' => 'text', // HTML input type
+			)
+		),
+		array(
+			'post',
+			'project-organization',
+			array(
+				'object_subtype' => 'projects',
+				'type' => 'string',
+				'description' => esc_html__( 'The organization responsible for this project.', 'currentorg' ),
+				'single' => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				// 'auth_callback' => .... I don't know the answer to this question.
+				'show_in_rest' => true,
+				'_projects_input_type' => 'text',
+			)
+		),
+		array(
+			'post',
+			'project-city',
+			array(
+				'object_subtype' => 'projects',
+				'type' => 'string',
+				'description' => esc_html__('The city where this organization is located.', 'currentorg' ),
+				'single' => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				// 'auth_callback' => .... I don't know the answer to this question.
+				'show_in_rest' => true,
+
+				// now for our private arguments
+				'_projects_input_type' => 'text', // HTML input type
+			)
+		),
+		array(
+			'post',
+			'project-state',
+			array(
+				'object_subtype' => 'projects',
+				'type' => 'string',
+				'description' => esc_html__('The state or territory where this organization is located.', 'currentorg' ),
+				'single' => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				// 'auth_callback' => .... I don't know the answer to this question.
+				'show_in_rest' => true,
+
+				// now for our private arguments
+				'_projects_input_type' => 'text', // HTML input type
+			)
+		),
+		array(
+			'post',
 			'project-contact-name',
 			array(
 				'object_subtype' => 'projects',
@@ -151,16 +229,130 @@ function projects_post_meta_items() {
 		),
 		array(
 			'post',
-			'project-organization',
+			'project-revenue',
 			array(
 				'object_subtype' => 'projects',
 				'type' => 'string',
-				'description' => esc_html__( 'The organization responsible for this project.', 'currentorg' ),
+				'description' => esc_html__('Did the initiative generate revenue?', 'currentorg' ),
+				'single' => true,
+				'sanitize_callback' => 'sanitize_textarea_field',
+				// 'auth_callback' => .... I don't know the answer to this question.
+				'show_in_rest' => true,
+
+				// now for our private arguments
+				'_projects_input_type' => 'textarea', // HTML input type
+			)
+		),
+		array(
+			'post',
+			'project-impact',
+			array(
+				'object_subtype' => 'projects',
+				'type' => 'string',
+				'description' => esc_html__('The project impact statement.', 'currentorg' ),
+				'single' => true,
+				'sanitize_callback' => 'sanitize_textarea_field',
+				// 'auth_callback' => .... I don't know the answer to this question.
+				'show_in_rest' => true,
+
+				// now for our private arguments
+				'_projects_input_type' => 'textarea', // HTML input type
+			)
+		),
+		array(
+			'post',
+			'project-link',
+			array(
+				'object_subtype' => 'projects',
+				'type' => 'string',
+				'description' => esc_html__('The public-facing link for this project.', 'currentorg' ),
 				'single' => true,
 				'sanitize_callback' => 'sanitize_text_field',
 				// 'auth_callback' => .... I don't know the answer to this question.
 				'show_in_rest' => true,
-				'_projects_input_type' => 'text',
+
+				// now for our private arguments
+				'_projects_input_type' => 'url', // HTML input type
+			)
+		),
+		array(
+			'post',
+			'project-additional-link-1',
+			array(
+				'object_subtype' => 'projects',
+				'type' => 'string',
+				'description' => esc_html__('Internal link for judging, #1.', 'currentorg' ),
+				'single' => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				// 'auth_callback' => .... I don't know the answer to this question.
+				'show_in_rest' => true,
+
+				// now for our private arguments
+				'_projects_input_type' => 'url', // HTML input type
+			)
+		),
+		array(
+			'post',
+			'project-additional-link-2',
+			array(
+				'object_subtype' => 'projects',
+				'type' => 'string',
+				'description' => esc_html__('Internal link for judging, #2.', 'currentorg' ),
+				'single' => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				// 'auth_callback' => .... I don't know the answer to this question.
+				'show_in_rest' => true,
+
+				// now for our private arguments
+				'_projects_input_type' => 'url', // HTML input type
+			)
+		),
+		array(
+			'post',
+			'project-additional-link-3',
+			array(
+				'object_subtype' => 'projects',
+				'type' => 'string',
+				'description' => esc_html__('Internal link for judging, #3.', 'currentorg' ),
+				'single' => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				// 'auth_callback' => .... I don't know the answer to this question.
+				'show_in_rest' => true,
+
+				// now for our private arguments
+				'_projects_input_type' => 'url', // HTML input type
+			)
+		),
+		array(
+			'post',
+			'project-additional-link-4',
+			array(
+				'object_subtype' => 'projects',
+				'type' => 'string',
+				'description' => esc_html__('Internal link for judging, #4.', 'currentorg' ),
+				'single' => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				// 'auth_callback' => .... I don't know the answer to this question.
+				'show_in_rest' => true,
+
+				// now for our private arguments
+				'_projects_input_type' => 'url', // HTML input type
+			)
+		),
+		array(
+			'post',
+			'project-additional-link-5',
+			array(
+				'object_subtype' => 'projects',
+				'type' => 'string',
+				'description' => esc_html__('Internal link for judging, #5.', 'currentorg' ),
+				'single' => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				// 'auth_callback' => .... I don't know the answer to this question.
+				'show_in_rest' => true,
+
+				// now for our private arguments
+				'_projects_input_type' => 'url', // HTML input type
 			)
 		),
 		array(
@@ -310,6 +502,7 @@ function projects_meta_box_callback( $post ) {
 				display: block;
 				font-size: 14px;
 			}
+			#current-ltw-project td textarea,
 			#current-ltw-project td input {
 				margin: 8px;
 				width: 96%;
@@ -344,7 +537,13 @@ function projects_meta_box_callback( $post ) {
 
 		switch ( $item[2]['_projects_input_type'] ) {
 			case 'textarea':
-				echo "This is a textarea!";
+				printf(
+					'<tr><td class="left"><label for="%1$s">%2$s</label></td><td class="right"><textarea id="%1$s" name="%1$s" class="" >%4$s</textarea></td></tr>',
+					esc_attr( $item[1] ),
+					esc_html( $item[2]['description'] ),
+					null,
+					esc_html( get_post_meta( $post->ID, $item[1], true ) )
+				);
 				break;
 			case 'url':
 			case 'text':

--- a/wp-content/plugins/current-ltw-projects/post-types/projects.php
+++ b/wp-content/plugins/current-ltw-projects/post-types/projects.php
@@ -305,3 +305,10 @@ function projects_meta_box_callback( $post ) {
 	echo '</tbody>';
 	echo '</table>';
 }
+
+add_action('largo_before_post_header', function() {
+	printf(
+		'<pre>%1$s</pre>',
+		esc_html( var_export( get_post_custom( get_the_ID() ), true) )
+	);
+});

--- a/wp-content/plugins/current-ltw-projects/post-types/projects.php
+++ b/wp-content/plugins/current-ltw-projects/post-types/projects.php
@@ -216,8 +216,13 @@ function projects_add_meta_box() {
 add_action( 'add_meta_boxes', 'projects_add_meta_box' );
 
 /*
- * There is no specific save callback for this item, because we've registered the post meta with sanitize callbacks
+ * Save callback for the project meta fields
+ *
+ * @uses projects_post_meta_items, specifically _projects_input_type and sanitize_callback
  */
+function projects_meta_save() {
+}
+
 
 /**
  * The meta box for the project meta fields

--- a/wp-content/plugins/current-ltw-projects/post-types/projects.php
+++ b/wp-content/plugins/current-ltw-projects/post-types/projects.php
@@ -216,13 +216,8 @@ function projects_add_meta_box() {
 add_action( 'add_meta_boxes', 'projects_add_meta_box' );
 
 /*
- * Save callback for the project meta fields
- *
- * @uses projects_post_meta_items, specifically _projects_input_type and sanitize_callback
+ * There is no specific save callback for this item, because we've registered the post meta with sanitize callbacks
  */
-function projects_meta_save() {
-}
-
 
 /**
  * The meta box for the project meta fields

--- a/wp-content/plugins/current-ltw-projects/post-types/projects.php
+++ b/wp-content/plugins/current-ltw-projects/post-types/projects.php
@@ -125,7 +125,7 @@ function projects_post_meta_items() {
 			array(
 				'object_subtype' => 'projects',
 				'type' => 'string',
-				'description' => esc_html__('The contact human for this project.', 'currentorg' ),
+				'description' => esc_html__('The public-facing human point-of-contact for this project.', 'currentorg' ),
 				'single' => true,
 				'sanitize_callback' => 'sanitize_text_field',
 				// 'auth_callback' => .... I don't know the answer to this question.
@@ -141,7 +141,7 @@ function projects_post_meta_items() {
 			array(
 				'object_subtype' => 'projects',
 				'type' => 'string',
-				'description' => esc_html__( 'The contact email for this project.', 'currentorg' ),
+				'description' => esc_html__( 'The public-facing contact email for this project.', 'currentorg' ),
 				'single' => true,
 				'sanitize_callback' => 'sanitize_text_field',
 				// 'auth_callback' => .... I don't know the answer to this question.
@@ -169,7 +169,7 @@ function projects_post_meta_items() {
 			array(
 				'object_subtype' => 'projects',
 				'type' => 'string',
-				'description' => esc_html__( 'Link to video URL for this project', 'currentorg' ),
+				'description' => esc_html__( 'Video URL for this project.', 'currentorg' ),
 				'single' => true,
 				'sanitize_callback' => 'esc_url_raw',
 				// 'auth_callback' => .... I don't know the answer to this question.


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Creates a metabox, save action, and metabox registration action for the `current-ltw-projects` plugin
- Creates an array containing information about post meta fields that is used to populate each of the three things above with the appropriate informaiton
- On the single-project page view, outputs the post custom meta in a debug function, to provide a non-editor verification that we've saved the things correctly.

![Screen Shot 2020-05-29 at 00 05 10](https://user-images.githubusercontent.com/1754187/83220481-137b1100-a141-11ea-80f3-0f346d5ad8c4.png)


## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #133 

## Testing/Questions

Features that this PR affects:

- editor on `projects` post type, in Gutenberg and Classic

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Does the usage of the `projects_post_meta_items()` function make sense and seem maintainable?
- [ ] Is the save function safe?
- [x] should we try to make a Gutenberg-powered meta box that will update with post-sanitization values, or is it acceptable to wait for the user to refresh the editor?
- [x] Do we need a separate option for delete_post_meta?

In the post editor for a project, test this by:

1. Fill out all fields with gibberish and junk that should not be accepted in that field type, like non-URLs in URL fields or HTML in text fields
2. Save the post; open the post in a new tab and view the post meta
3. Empty all fields, save, verify that the post custom values are now all empty strings
4. Fill fields with sensible information, verify that save works.