### PR TITLE
Remove debug code from LTW plugin

### DIFF
--- a/wp-content/plugins/current-ltw-projects/post-types/projects.php
+++ b/wp-content/plugins/current-ltw-projects/post-types/projects.php
@@ -567,13 +567,6 @@ function projects_meta_box_callback( $post ) {
 	echo '</table>';
 }
 
-add_action('largo_before_post_header', function() {
-	printf(
-		'<pre>%1$s</pre>',
-		esc_html( var_export( get_post_custom( get_the_ID() ), true) )
-	);
-});
-
 /**
  * Remove the filter that allows users to filter projects by M/Y
  * 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes the debug code from the LTW projects plugin at https://github.com/INN/umbrella-currentorg/blob/44bce795e32467b09425d7442059a0e739ad83c3/wp-content/plugins/current-ltw-projects/post-types/projects.php#L568-L573

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #155

## Testing/Questions

Features that this PR affects:

- Nothing, really

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Any other debug code that needs removed?

Steps to test this PR:

1. View a post/page/etc. and make sure the debug code doesn't appear